### PR TITLE
[dev] worker properties change from powerjob.xxx to powerjob.worker.xxx

### DIFF
--- a/powerjob-worker-samples/src/main/resources/application.properties
+++ b/powerjob-worker-samples/src/main/resources/application.properties
@@ -4,10 +4,10 @@ spring.jpa.open-in-view=false
 
 ########### powerjob-worker 配置 ###########
 # akka 工作端口，可选，默认 27777
-powerjob.akka-port=27777
+powerjob.worker.akka-port=27777
 # 接入应用名称，用于分组隔离，推荐填写 本 Java 项目名称
-powerjob.app-name=powerjob-agent-test
+powerjob.worker.app-name=powerjob-agent-test
 # 调度服务器地址，IP:Port 或 域名，多值逗号分隔
-powerjob.server-address=127.0.0.1:7700,127.0.0.1:7701
+powerjob.worker.server-address=127.0.0.1:7700,127.0.0.1:7701
 # 持久化方式，可选，默认 disk
-powerjob.store-strategy=disk
+powerjob.worker.store-strategy=disk

--- a/powerjob-worker-spring-boot-starter/src/main/java/com/github/kfcfans/powerjob/worker/autoconfigure/PowerJobAutoConfiguration.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/com/github/kfcfans/powerjob/worker/autoconfigure/PowerJobAutoConfiguration.java
@@ -3,9 +3,12 @@ package com.github.kfcfans.powerjob.worker.autoconfigure;
 import com.github.kfcfans.powerjob.common.utils.CommonUtils;
 import com.github.kfcfans.powerjob.worker.OhMyWorker;
 import com.github.kfcfans.powerjob.worker.common.OhMyConfig;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.Arrays;
@@ -19,32 +22,53 @@ import java.util.List;
  */
 @Configuration
 @EnableConfigurationProperties(PowerJobProperties.class)
+@Conditional(PowerJobAutoConfiguration.PowerJobWorkerCondition.class)
 public class PowerJobAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
     public OhMyWorker initPowerJob(PowerJobProperties properties) {
 
+        PowerJobProperties.Worker worker = properties.getWorker();
+
         // 服务器HTTP地址（端口号为 server.port，而不是 ActorSystem port），请勿添加任何前缀（http://）
-        CommonUtils.requireNonNull(properties.getServerAddress(), "serverAddress can't be empty!");
-        List<String> serverAddress = Arrays.asList(properties.getServerAddress().split(","));
+        CommonUtils.requireNonNull(worker.getServerAddress(), "serverAddress can't be empty!");
+        List<String> serverAddress = Arrays.asList(worker.getServerAddress().split(","));
 
         // 1. 创建配置文件
         OhMyConfig config = new OhMyConfig();
         // 可以不显式设置，默认值 27777
-        config.setPort(properties.getAkkaPort());
+        config.setPort(worker.getAkkaPort());
         // appName，需要提前在控制台注册，否则启动报错
-        config.setAppName(properties.getAppName());
+        config.setAppName(worker.getAppName());
         config.setServerAddress(serverAddress);
         // 如果没有大型 Map/MapReduce 的需求，建议使用内存来加速计算
         // 有大型 Map/MapReduce 需求，可能产生大量子任务（Task）的场景，请使用 DISK，否则妥妥的 OutOfMemory
-        config.setStoreStrategy(properties.getStoreStrategy());
+        config.setStoreStrategy(worker.getStoreStrategy());
         // 启动测试模式，true情况下，不再尝试连接 server 并验证appName
-        config.setEnableTestMode(properties.isEnableTestMode());
+        config.setEnableTestMode(worker.isEnableTestMode());
 
         // 2. 创建 Worker 对象，设置配置文件
         OhMyWorker ohMyWorker = new OhMyWorker();
         ohMyWorker.setConfig(config);
         return ohMyWorker;
+    }
+
+    static class PowerJobWorkerCondition extends AnyNestedCondition {
+
+        public PowerJobWorkerCondition() {
+            super(ConfigurationPhase.PARSE_CONFIGURATION);
+        }
+
+        @Deprecated
+        @ConditionalOnProperty(prefix = "powerjob", name = "server-address")
+        static class PowerJobProperty {
+
+        }
+
+        @ConditionalOnProperty(prefix = "powerjob.worker", name = "server-address")
+        static class PowerJobWorkerProperty {
+
+        }
     }
 }

--- a/powerjob-worker-spring-boot-starter/src/main/java/com/github/kfcfans/powerjob/worker/autoconfigure/PowerJobProperties.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/com/github/kfcfans/powerjob/worker/autoconfigure/PowerJobProperties.java
@@ -3,8 +3,10 @@ package com.github.kfcfans.powerjob.worker.autoconfigure;
 import com.github.kfcfans.powerjob.common.RemoteConstant;
 import com.github.kfcfans.powerjob.worker.common.constants.StoreStrategy;
 import com.github.kfcfans.powerjob.worker.core.processor.ProcessResult;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * PowerJob 配置项
@@ -12,33 +14,114 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author songyinyin
  * @since 2020/7/26 16:37
  */
-@Data
 @ConfigurationProperties(prefix = "powerjob")
 public class PowerJobProperties {
+
+    private final Worker worker = new Worker();
+
+    public Worker getWorker() {
+        return worker;
+    }
+
+    @Deprecated
+    @DeprecatedConfigurationProperty(replacement = "powerjob.worker.app-name")
+    public String getAppName() {
+        return getWorker().appName;
+    }
+
+    @Deprecated
+    public void setAppName(String appName) {
+        getWorker().setAppName(appName);
+    }
+
+    @Deprecated
+    @DeprecatedConfigurationProperty(replacement = "powerjob.worker.akka-port")
+    public int getAkkaPort() {
+        return getWorker().akkaPort;
+    }
+
+    @Deprecated
+    public void setAkkaPort(int akkaPort) {
+        getWorker().setAkkaPort(akkaPort);
+    }
+
+    @Deprecated
+    @DeprecatedConfigurationProperty(replacement = "powerjob.worker.server-address")
+    public String getServerAddress() {
+        return getWorker().serverAddress;
+    }
+
+    @Deprecated
+    public void setServerAddress(String serverAddress) {
+        getWorker().setServerAddress(serverAddress);
+    }
+
+    @Deprecated
+    @DeprecatedConfigurationProperty(replacement = "powerjob.worker.store-strategy")
+    public StoreStrategy getStoreStrategy() {
+        return getWorker().storeStrategy;
+    }
+
+    @Deprecated
+    public void setStoreStrategy(StoreStrategy storeStrategy) {
+        getWorker().setStoreStrategy(storeStrategy);
+    }
+
+    @Deprecated
+    @DeprecatedConfigurationProperty(replacement = "powerjob.worker.max-result-length")
+    public int getMaxResultLength() {
+        return getWorker().maxResultLength;
+    }
+
+    @Deprecated
+    public void setMaxResultLength(int maxResultLength) {
+        getWorker().setMaxResultLength(maxResultLength);
+    }
+
+    @Deprecated
+    @DeprecatedConfigurationProperty(replacement = "powerjob.worker.enable-test-mode")
+    public boolean isEnableTestMode() {
+        return getWorker().enableTestMode;
+    }
+
+    @Deprecated
+    public void setEnableTestMode(boolean enableTestMode) {
+        getWorker().setEnableTestMode(enableTestMode);
+    }
+
+
+
     /**
-     * 应用名称，需要提前在控制台注册，否则启动报错
+     * 客户端 配置项
      */
-    private String appName;
-    /**
-     * 启动 akka 端口
-     */
-    private int akkaPort = RemoteConstant.DEFAULT_WORKER_PORT;
-    /**
-     * 调度服务器地址，ip:port 或 域名，多个用英文逗号分隔
-     */
-    private String serverAddress;
-    /**
-     * 本地持久化方式，默认使用磁盘
-     */
-    private StoreStrategy storeStrategy = StoreStrategy.DISK;
-    /**
-     * 最大返回值长度，超过会被截断
-     * {@link ProcessResult}#msg 的最大长度
-     */
-    private int maxResultLength = 8096;
-    /**
-     * 启动测试模式，true情况下，不再尝试连接 server 并验证appName。
-     * true -> 用于本地写单元测试调试； false -> 默认值，标准模式
-     */
-    private boolean enableTestMode = false;
+    @Setter
+    @Getter
+    public static class Worker {
+        /**
+         * 应用名称，需要提前在控制台注册，否则启动报错
+         */
+        private String appName;
+        /**
+         * 启动 akka 端口
+         */
+        private int akkaPort = RemoteConstant.DEFAULT_WORKER_PORT;
+        /**
+         * 调度服务器地址，ip:port 或 域名，多个用英文逗号分隔
+         */
+        private String serverAddress;
+        /**
+         * 本地持久化方式，默认使用磁盘
+         */
+        private StoreStrategy storeStrategy = StoreStrategy.DISK;
+        /**
+         * 最大返回值长度，超过会被截断
+         * {@link ProcessResult}#msg 的最大长度
+         */
+        private int maxResultLength = 8096;
+        /**
+         * 启动测试模式，true情况下，不再尝试连接 server 并验证appName。
+         * true -> 用于本地写单元测试调试； false -> 默认值，标准模式
+         */
+        private boolean enableTestMode = false;
+    }
 }

--- a/powerjob-worker-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/powerjob-worker-spring-boot-starter/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -4,46 +4,106 @@
       "name": "powerjob",
       "type": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
       "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties"
+    },
+    {
+      "name": "powerjob.worker",
+      "type": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties$Worker",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
+      "sourceMethod": "getWorker()"
     }
   ],
   "properties": [
     {
-      "name": "powerjob.app-name",
-      "type": "java.lang.String",
-      "description": "应用名称，需要提前在控制台注册，否则启动报错",
-      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties"
+      "name": "powerjob.worker.akka-port",
+      "type": "java.lang.Integer",
+      "description": "启动 akka 端口",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties$Worker"
     },
     {
-      "name": "powerjob.max-result-length",
+      "name": "powerjob.worker.app-name",
+      "type": "java.lang.String",
+      "description": "应用名称，需要提前在控制台注册，否则启动报错",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties$Worker"
+    },
+    {
+      "name": "powerjob.worker.enable-test-mode",
+      "type": "java.lang.Boolean",
+      "description": "启动测试模式，true情况下，不再尝试连接 server 并验证appName。 true -> 用于本地写单元测试调试； false -> 默认值，标准模式",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties$Worker",
+      "defaultValue": false
+    },
+    {
+      "name": "powerjob.worker.max-result-length",
       "type": "java.lang.Integer",
       "description": "最大返回值长度，超过会被截断 {@link ProcessResult}#msg 的最大长度",
-      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties$Worker",
       "defaultValue": 8096
+    },
+    {
+      "name": "powerjob.worker.server-address",
+      "type": "java.lang.String",
+      "description": "调度服务器地址，ip:port 或 域名，多个用英文逗号分隔",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties$Worker"
+    },
+    {
+      "name": "powerjob.worker.store-strategy",
+      "type": "com.github.kfcfans.powerjob.worker.common.constants.StoreStrategy",
+      "description": "本地持久化方式，默认使用磁盘",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties$Worker"
     },
     {
       "name": "powerjob.akka-port",
       "type": "java.lang.Integer",
-      "description": "启动 akka 端口",
-      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties"
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
+      "deprecated": true,
+      "deprecation": {
+        "replacement": "powerjob.worker.akka-port"
+      }
     },
     {
-      "name": "powerjob.server-address",
+      "name": "powerjob.app-name",
       "type": "java.lang.String",
-      "description": "调度服务器地址，ip:port 或 域名，多值用英文逗号分隔",
-      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties"
-    },
-    {
-      "name": "powerjob.store-strategy",
-      "type": "com.github.kfcfans.powerjob.worker.common.constants.StoreStrategy",
-      "description": "本地持久化方式，默认使用磁盘",
-      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties"
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
+      "deprecated": true,
+      "deprecation": {
+        "replacement": "powerjob.worker.app-name"
+      }
     },
     {
       "name": "powerjob.enable-test-mode",
       "type": "java.lang.Boolean",
-      "description": "启动测试模式，true情况下，不再尝试连接 server 并验证appName。true -> 用于本地写单元测试调试； false -> 默认值，标准模式",
       "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
-      "defaultValue": false
+      "deprecated": true,
+      "deprecation": {
+        "replacement": "powerjob.worker.enable-test-mode"
+      }
+    },
+    {
+      "name": "powerjob.max-result-length",
+      "type": "java.lang.Integer",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
+      "deprecated": true,
+      "deprecation": {
+        "replacement": "powerjob.worker.max-result-length"
+      }
+    },
+    {
+      "name": "powerjob.server-address",
+      "type": "java.lang.String",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
+      "deprecated": true,
+      "deprecation": {
+        "replacement": "powerjob.worker.server-address"
+      }
+    },
+    {
+      "name": "powerjob.store-strategy",
+      "type": "com.github.kfcfans.powerjob.worker.common.constants.StoreStrategy",
+      "sourceType": "com.github.kfcfans.powerjob.worker.autoconfigure.PowerJobProperties",
+      "deprecated": true,
+      "deprecation": {
+        "replacement": "powerjob.worker.store-strategy"
+      }
     }
   ],
   "hints": []


### PR DESCRIPTION
1. worker 配置项从powerjob.xxx改为powerjob.worker.xxx，并兼容之前的版本（powerjob.xxx 标记已过期）
2. `powerjob.worker.server-address`没有该配置项时，应用不启动PowerJob worker